### PR TITLE
Update to HTTPS URLs

### DIFF
--- a/crop_world.tuttle
+++ b/crop_world.tuttle
@@ -1,5 +1,5 @@
 # Téléchargment de l'outil traitement d'OSM
-file://osmosis-latest.tgz <- http://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz ! download
+file://osmosis-latest.tgz <- https://bretth.dev.openstreetmap.org/osmosis-build/osmosis-latest.tgz ! download
 
 file://osmosis <- file://osmosis-latest.tgz
     mkdir osmosis
@@ -9,7 +9,7 @@ file://osmosis <- file://osmosis-latest.tgz
 
 
 # Extraction d'une base OSM France OSM
-file://planet-latest.osm.pbf <- http://planet.osm.org/pbf/planet-latest.osm.pbf ! download
+file://planet-latest.osm.pbf <- https://planet.osm.org/pbf/planet-latest.osm.pbf ! download
 
 file://planet-france.osm.pbf <- file://planet-latest.osm.pbf file://osmosis
     osmosis/bin/osmosis --read-pbf planet-latest.osm.pbf --bounding-box top=51.15 left=-5.2 bottom=42.3 right=8.32 --write-pbf planet-france.osm.pbf


### PR DESCRIPTION
planet.openstreetmap.org will redirect to HTTPS at some point in the future.
In addition to that change, I moved the other URLs in this configuration to HTTPS.
This is particularly important for Osmosis, where a binary is downloaded.

See also openstreetmap/operations#200